### PR TITLE
nvme/core: correction to specifying irq vectors

### DIFF
--- a/examples/io.c
+++ b/examples/io.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 	if (nvme_init(&ctrl, bdf, &ctrl_opts))
 		err(1, "failed to init nvme controller");
 
-	if (nvme_create_ioqpair(&ctrl, 1, 64, 0x0, -1))
+	if (nvme_create_ioqpair(&ctrl, 1, 64, -1, 0x0))
 		err(1, "could not create io queue pair");
 
 	vaddr = mmap(NULL, 0x1000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);

--- a/examples/perf.c
+++ b/examples/perf.c
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
 
 	nsze = le64_to_cpu((__force leint64_t)(id_ns->nsze));
 
-	if (nvme_create_ioqpair(&ctrl, 1, qsize, 0x0, -1))
+	if (nvme_create_ioqpair(&ctrl, 1, qsize, -1, 0x0))
 		err(1, "nvme_create_ioqpair");
 
 	sq = &ctrl.sq[1];

--- a/tests/device/common.c
+++ b/tests/device/common.c
@@ -68,7 +68,7 @@ void setup_io(int argc, char *argv[])
 {
 	setup(argc, argv);
 
-	if (nvme_create_ioqpair(&ctrl, 1, 8, 0x0, -1))
+	if (nvme_create_ioqpair(&ctrl, 1, 8, -1, 0x0))
 		err(1, "could not create i/o queue pair");
 
 	sq = &ctrl.sq[1];


### PR DESCRIPTION
The flags and vector arguments were accidently flipped in the examples and tests for nvme_create_ioqpair.