### PR TITLE
vfio: remove ephemeral mappings

### DIFF
--- a/examples/cmb-p2p.c
+++ b/examples/cmb-p2p.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 		.dptr.prp1 = cpu_to_le64(hwaddr),
 	};
 
-	if (nvme_admin(&src, &cmd, NULL, 0x0, NULL))
+	if (nvme_admin(&src, &cmd, NULL, 0, NULL))
 		err(1, "nvme_admin");
 
 	id_ctrl = (struct nvme_id_ctrl __force *)cmb;

--- a/examples/cmb.c
+++ b/examples/cmb.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 
 	cmd.identify.cns = NVME_IDENTIFY_CNS_CTRL;
 
-	if (nvme_admin(&ctrl, &cmd, NULL, 0x0, NULL))
+	if (nvme_admin(&ctrl, &cmd, NULL, 0, NULL))
 		err(1, "nvme_admin");
 
 	id_ctrl = (struct nvme_id_ctrl __force *)cmb;

--- a/examples/eventfd.c
+++ b/examples/eventfd.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 
 	vaddr = mmap(NULL, 0x1000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
 
-	if (vfio_map_vaddr(ctrl.pci.dev.vfio, vaddr, 0x1000, &iova))
+	if (vfio_map_vaddr(ctrl.pci.dev.vfio, vaddr, 0x1000, &iova, 0x0))
 		err(1, "failed to reserve iova");
 
 	rq = nvme_rq_acquire(&ctrl.sq[1]);

--- a/examples/io.c
+++ b/examples/io.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
 	vaddr = mmap(NULL, 0x1000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
 
-	if (vfio_map_vaddr(ctrl.pci.dev.vfio, vaddr, 0x1000, &iova))
+	if (vfio_map_vaddr(ctrl.pci.dev.vfio, vaddr, 0x1000, &iova, 0x0))
 		err(1, "failed to reserve iova");
 
 	if (op_write) {

--- a/examples/perf.c
+++ b/examples/perf.c
@@ -174,7 +174,7 @@ static void run(void)
 	if (!mem)
 		err(1, "mmap");
 
-	if (vfio_map_vaddr(ctrl.pci.dev.vfio, mem, io_depth * 0x1000, &iova))
+	if (vfio_map_vaddr(ctrl.pci.dev.vfio, mem, io_depth * 0x1000, &iova, 0x0))
 		err(1, "failed to map");
 
 	do {

--- a/include/vfn/nvme/util.h
+++ b/include/vfn/nvme/util.h
@@ -68,11 +68,10 @@ int nvme_set_errno_from_cqe(struct nvme_cqe *cqe);
 int nvme_aer(struct nvme_ctrl *ctrl, void *opaque);
 
 /**
- * nvme_oneshot - Submit a command and wait for completion
- * @ctrl: Controller reference
+ * nvme_sync - Submit a command and wait for completion
  * @sq: Submission queue
  * @sqe: Submission queue entry
- * @buf: Command payload
+ * @iova: Mapped command payload
  * @len: Command payload length
  * @cqe: Completion queue entry to fill
  *
@@ -81,15 +80,14 @@ int nvme_aer(struct nvme_ctrl *ctrl, void *opaque);
  * different from the one set in @sqe), the CQE is ignored and an error message
  * is logged.
  *
- * **Note**: As the name indicate, this function should only be used for "one
- * shot" commands where no spurious CQEs are expected to be posted on the
- * completion queue.
+ * **Note**: This function should only be used for synchronous commands where no
+ * spurious CQEs are expected to be posted on the completion queue. Any spurious
+ * CQEs will be logged and dropped.
  *
  * Return: On success, returns ``0``. On error, returns ``-1`` and sets
  * ``errno``.
  */
-int nvme_oneshot(struct nvme_ctrl *ctrl, struct nvme_sq *sq, void *sqe, void *buf, size_t len,
-		 void *cqe);
+int nvme_sync(struct nvme_sq *sq, void *sqe, uint64_t iova, size_t len, void *cqe);
 
 /**
  * nvme_admin - Submit an Admin command and wait for completion
@@ -99,7 +97,8 @@ int nvme_oneshot(struct nvme_ctrl *ctrl, struct nvme_sq *sq, void *sqe, void *bu
  * @len: Command payload length
  * @cqe: Completion queue entry to fill
  *
- * Shortcut for nvme_oneshot(), submitting to the admin submission queue.
+ * Shortcut for nvme_sync(), mapping the buffer using the reserved iova space
+ * and submitting to the admin submission queue.
  *
  * Return: On success, returns ``0``. On error, returnes ``-1`` and sets
  * ``errno``.

--- a/src/vfio/iommu.h
+++ b/src/vfio/iommu.h
@@ -10,8 +10,7 @@
  * COPYING and LICENSE files for more information.
  */
 
-#define VFIO_IOVA_MIN 0x0
-#define VFIO_IOVA_MAX (1ULL << 39)
+#define IOVA_MAX_39BITS (1ULL << 39)
 
 struct iova_mapping {
 	void *vaddr;
@@ -27,8 +26,7 @@ struct iommu_state {
 
 	pthread_mutex_t lock;
 
-	uint64_t top, bottom;
-	unsigned long long nephemeral;
+	uint64_t next;
 
 	void *map;
 };
@@ -39,11 +37,7 @@ void iommu_destroy(struct iommu_state *iommu);
 int iommu_add_mapping(struct iommu_state *iommu, void *vaddr, size_t len, uint64_t iova);
 void iommu_remove_mapping(struct iommu_state *iommu, void *vaddr);
 
-int iommu_allocate_sticky_iova(struct iommu_state *iommu, size_t len, uint64_t *iova);
-int iommu_allocate_iova(struct iommu_state *iommu, size_t len, uint64_t *iova, bool ephemeral);
-int iommu_get_ephemeral_iova(struct iommu_state *iommu, size_t len, uint64_t *iova);
-void iommu_put_ephemeral_iova(struct iommu_state *iommu);
-void iommu_recycle_ephemeral_iovas(struct iommu_state *iommu);
+int iommu_get_iova(struct iommu_state *iommu, size_t len, uint64_t *iova);
 bool iommu_vaddr_to_iova(struct iommu_state *iommu, void *vaddr, uint64_t *iova);
 struct iova_mapping *iommu_find_mapping(struct iommu_state *iommu, void *vaddr);
 void iommu_clear(struct iommu_state *iommu);

--- a/tests/device/aer.c
+++ b/tests/device/aer.c
@@ -96,7 +96,7 @@ static int test_aer(void)
 		.cdw11 = cpu_to_le32(NVME_SET(NVME_SMART_CRIT_TEMPERATURE, FEAT_AE_SMART)),
 	};
 
-	if (nvme_admin(&ctrl, &cmd, NULL, 0x0, NULL))
+	if (nvme_admin(&ctrl, &cmd, NULL, 0, NULL))
 		err(1, "could not set asynchronous event configuration");
 
 	cmd.features = (struct nvme_cmd_features) {
@@ -104,7 +104,7 @@ static int test_aer(void)
 		.fid = NVME_FEAT_FID_TEMP_THRESH,
 	};
 
-	if (nvme_admin(&ctrl, &cmd, NULL, 0x0, &cqe))
+	if (nvme_admin(&ctrl, &cmd, NULL, 0, &cqe))
 		err(1, "could not get current temperature threshold");
 
 	temp_thresh = le32_to_cpu(cqe.dw0);
@@ -156,7 +156,7 @@ static int test_aer(void)
 		.cdw11 = cpu_to_le32(NVME_SET(temp_thresh, FEAT_TT_TMPTH)),
 	};
 
-	if (nvme_admin(&ctrl, &cmd, NULL, 0x0, &cqe))
+	if (nvme_admin(&ctrl, &cmd, NULL, 0, &cqe))
 		err(1, "could not reset temperature threshold");
 
 	if (get_smart_log())

--- a/tests/device/flush.c
+++ b/tests/device/flush.c
@@ -37,7 +37,7 @@ static int test_flush(uint32_t nsid)
 		.nsid = cpu_to_le32(nsid),
 	};
 
-	return nvme_oneshot(&ctrl, sq, &cmd, NULL, 0x0, NULL);
+	return nvme_sync(sq, &cmd, 0x0, 0, NULL);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Until now we have used an allocation strategy similar to that from the vfio helpers in QEMU. That is, we allocate "sticky" or "fixed" iovas from low addresses in the iova space and "ephemeral" or "temporary" iovas from high addresses. This works well, but they are rarely used and as we move towards an iommufd-first backend we will start to use automatic iova allocation through the kernel allocator.

Drop the ephemeral mapping functionality and instead reserve the low 64k of the iova address space for internal use.