### PR TITLE
vfio/pci: add `vfio_pci_get_irq_info()`

### DIFF
--- a/include/vfn/vfio/pci.h
+++ b/include/vfn/vfio/pci.h
@@ -64,6 +64,19 @@ int vfio_pci_open(struct vfio_pci_device *pci, const char *bdf);
 int vfio_pci_close(struct vfio_pci_device *pci);
 
 /**
+ * vfio_pci_get_irq_info - get &struct vfio_irq_info
+ * @pci: &struct vfio_pci_device
+ * @irq: &struct vfio_irq_info to copy to
+ *
+ * Caller should provide @irq instance with @irq->argsz filled with the number
+ * of bytes to copy from the @pci instance.
+ *
+ * Return: On success, returns ``0``. On error, returns ``-1`` and sets
+ * ``errno``.
+ */
+int vfio_pci_get_irq_info(struct vfio_pci_device *pci, struct vfio_irq_info *irq);
+
+/**
  * vfio_pci_map_bar - map a vfio device region into virtual memory
  * @pci: &struct vfio_pci_device
  * @idx: the vfio region index to map

--- a/src/vfio/pci.c
+++ b/src/vfio/pci.c
@@ -109,6 +109,19 @@ static int vfio_pci_init_irq(struct vfio_pci_device *pci)
 	return 0;
 }
 
+int vfio_pci_get_irq_info(struct vfio_pci_device *pci, struct vfio_irq_info *irq)
+{
+	int size = irq->argsz ? irq->argsz : sizeof(struct vfio_irq_info);
+
+	if (!pci->bdf) {
+		errno = ENODEV;
+		return -1;
+	}
+
+	memcpy(irq, &pci->dev.irq_info, size);
+	return 0;
+}
+
 void *vfio_pci_map_bar(struct vfio_pci_device *pci, int idx, size_t len, uint64_t offset,
 		       int prot)
 {


### PR DESCRIPTION
Application can directly access (&struct nvme_ctrl)->pci.dev.irq_info after `nvme_ctrl_init()` to get the IRQ information provided by the vfio-pci kernel driver.  If kernel UAPI header vfio.h has different data structures for ioctl, which are &struct vfio_device_info and &struct vfio_irq_info, between build environment of libvfn's and app's.

Kernel Commit a881b496941f ("vfio: align capability structures") has added `__u32 pad` to &struct vfio_device_info and if some build environment has not been aware of this addition, libvfn might have been built without `pad` attribute in the &struct vfio_device_info.

&struct vfio_device provided in libvfn has continuous struct data structures:

	struct vfio_device {
		int fd;

		struct iommu_ctx *ctx;

		struct vfio_device_info device_info;  <-- updated
		struct vfio_irq_info irq_info;
	};

If application build environment has latest kernel UAPI and built with awareness of `pad` structure in &struct vfio_device_info, the @irq_info will be shifted and it goes wrong when application tries to access the @irq_info directly.

This patch addded a public API to copy the initialized &struct vfio_irq_info to the caller with the number of bytes caller requests by @irq_info->argsz just like the kernel ioctl handler does.