### PR TITLE
Fix C++ compilation: cast void* before pointer arithmetic

### DIFF
--- a/include/vfn/nvme/queue.h
+++ b/include/vfn/nvme/queue.h
@@ -78,7 +78,7 @@ struct nvme_sq {
  */
 static inline void nvme_sq_post(struct nvme_sq *sq, const union nvme_cmd *sqe)
 {
-	memcpy(sq->mem.vaddr + (sq->tail << NVME_SQES), sqe, 1 << NVME_SQES);
+	memcpy((char *)sq->mem.vaddr + (sq->tail << NVME_SQES), sqe, 1 << NVME_SQES);
 
 	trace_guard(NVME_SQ_POST) {
 		trace_emit("sqid %d tail %d\n", sq->id, sq->tail);
@@ -168,7 +168,7 @@ static inline void nvme_sq_exec(struct nvme_sq *sq, const union nvme_cmd *sqe)
  */
 static inline struct nvme_cqe *nvme_cq_head(struct nvme_cq *cq)
 {
-	return (struct nvme_cqe *)(cq->mem.vaddr + (cq->head << NVME_CQES));
+	return (struct nvme_cqe *)((char *)cq->mem.vaddr + (cq->head << NVME_CQES));
 }
 
 /**

--- a/include/vfn/support/mmio.h
+++ b/include/vfn/support/mmio.h
@@ -40,7 +40,7 @@ static inline leint64_t mmio_lh_read64(void *addr)
 	/* memory-mapped register */
 	lo = *(const volatile uint32_t __force *)addr;
 	/* memory-mapped register */
-	hi = *(const volatile uint32_t __force *)(addr + 4);
+	hi = *(const volatile uint32_t __force *)((char *)addr + 4);
 
 	return (leint64_t __force)(((uint64_t)hi << 32) | lo);
 }
@@ -69,7 +69,7 @@ static inline void mmio_write32(void *addr, leint32_t v)
 static inline void mmio_lh_write64(void *addr, leint64_t v)
 {
 	mmio_write32(addr, (leint32_t __force)v);
-	mmio_write32(addr + 4, (leint32_t __force)((uint64_t __force)v >> 32));
+	mmio_write32((char *)addr + 4, (leint32_t __force)((uint64_t __force)v >> 32));
 }
 
 /**
@@ -82,7 +82,7 @@ static inline void mmio_lh_write64(void *addr, leint64_t v)
  */
 static inline void mmio_hl_write64(void *addr, leint64_t v)
 {
-	mmio_write32(addr + 4, (leint32_t __force)((uint64_t __force)v >> 32));
+	mmio_write32((char *)addr + 4, (leint32_t __force)((uint64_t __force)v >> 32));
 	mmio_write32(addr, (leint32_t __force)v);
 }
 


### PR DESCRIPTION
Fixes C++ compilation errors. The code uses pointer arithmetic on void*, which is a GNU C extension that works in C mode but is not allowed in C++.

Error example:
```
error: arithmetic on a pointer to void
   43 |         hi = *(const volatile uint32_t __force *)(addr + 4);
      |                                                   ~~~~ ^
```