### PR TITLE
Add support for allocating memory that has the same iova as its virtual address

### DIFF
--- a/examples/eventfd.c
+++ b/examples/eventfd.c
@@ -45,7 +45,8 @@ static struct opt_table opts[] = {
 int main(int argc, char **argv)
 {
 	void *vaddr;
-	uint64_t iova, v;
+	iova_t iova;
+	uint64_t v;
 	int ret, efd, efds[2] = {-1, -1};
 
 	struct nvme_ctrl ctrl = {};

--- a/examples/io.c
+++ b/examples/io.c
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-static bool op_write, op_read, op_same_iova;
+static bool op_write, op_read, op_same_iova, op_sgl, op_vector;
 static unsigned int op_len;
 static unsigned long nsid;
 static int fd;
@@ -41,8 +41,11 @@ static struct opt_table opts[] = {
 	OPT_WITH_ARG("-N|--nsid", opt_set_ulongval, opt_show_ulongval, &nsid, "namespace identifier"),
 	OPT_WITHOUT_ARG("-w|--write", opt_set_bool, &op_write, "perform a write"),
 	OPT_WITHOUT_ARG("-r|--read", opt_set_bool, &op_read, "perform a read"),
+	OPT_WITHOUT_ARG("-s|--sgl", opt_set_bool, &op_sgl,
+			"use sgls in operation"),
 	OPT_WITHOUT_ARG("-S|--same-iova", opt_set_bool, &op_same_iova,
 			"use memory with the same iova"),
+	OPT_WITHOUT_ARG("-v|--vector", opt_set_bool, &op_vector, "use a vectored operation"),
 	OPT_WITH_ARG("-z|--size", opt_set_uintval_bi, opt_show_uintval_bi, &op_len, "size of operation"),
 	OPT_ENDTABLE,
 };
@@ -50,8 +53,10 @@ static struct opt_table opts[] = {
 int main(int argc, char **argv)
 {
 	size_t io_sz = 0x1000;
+	struct iovec iov[2];
 	void *vaddr;
 	iova_t iova;
+	int niov;
 	int ret;
 
 	struct nvme_ctrl ctrl = {};
@@ -71,6 +76,9 @@ int main(int argc, char **argv)
 		opt_usage_exit_fail("specify one of -r or -w");
 
 	opt_free_table();
+
+	if (op_vector || op_sgl)
+		io_sz *= 2;
 
 	fd = op_read ? STDOUT_FILENO : STDIN_FILENO;
 
@@ -111,9 +119,37 @@ int main(int argc, char **argv)
 		.nsid = cpu_to_le32(nsid),
 	};
 
-	ret = nvme_rq_map_prp(&ctrl, rq, &cmd, iova, io_sz);
-	if (ret)
-		err(1, "could not map prps");
+	if (op_vector) {
+		iov[0].iov_base = vaddr + (io_sz / 2);
+		iov[0].iov_len = io_sz / 2;
+		iov[1].iov_base = vaddr;
+		iov[1].iov_len = io_sz / 2;
+		/*
+		 * note: this assumes the device has an lba size of 512B.
+		 * A 0xf (Data SGL Length Invalid) status code will be
+		 * returned in sgl mode if this is not the case.
+		 */
+		cmd.rw.nlb = cpu_to_le16(15);
+		niov = 2;
+	} else {
+		iov[0].iov_base = vaddr;
+		iov[0].iov_len = io_sz;
+		niov = 1;
+	}
+
+	if (op_sgl) {
+		ret = nvme_rq_mapv_sgl(&ctrl, rq, &cmd, iov, niov);
+		if (ret)
+			err(1, "could not map sgls");
+	} else if (op_vector) {
+		ret = nvme_rq_mapv_prp(&ctrl, rq, &cmd, iov, niov);
+		if (ret)
+			err(1, "could not map vectored prps");
+	} else {
+		ret = nvme_rq_map_prp(&ctrl, rq, &cmd, iova, io_sz);
+		if (ret)
+			err(1, "could not map prps");
+	}
 
 	nvme_rq_exec(rq, &cmd);
 

--- a/examples/io.c
+++ b/examples/io.c
@@ -49,6 +49,7 @@ static struct opt_table opts[] = {
 
 int main(int argc, char **argv)
 {
+	size_t io_sz = 0x1000;
 	void *vaddr;
 	iova_t iova;
 	int ret;
@@ -80,23 +81,23 @@ int main(int argc, char **argv)
 		err(1, "could not create io queue pair");
 
 	if (op_same_iova) {
-		vaddr = iommu_alloc_same_iova(__iommu_ctx(&ctrl), 0x1000);
+		vaddr = iommu_alloc_same_iova(__iommu_ctx(&ctrl), io_sz);
 		if (!vaddr)
 			err(1, "unable to allocate memory with same address as the iova");
 
 		iova = same_iova(vaddr);
 	} else {
-		vaddr = mmap(NULL, 0x1000, PROT_READ | PROT_WRITE,
+		vaddr = mmap(NULL, io_sz, PROT_READ | PROT_WRITE,
 			     MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
 
-		if (iommu_map_vaddr(__iommu_ctx(&ctrl), vaddr, 0x1000, &iova, 0x0))
+		if (iommu_map_vaddr(__iommu_ctx(&ctrl), vaddr, io_sz, &iova, 0x0))
 			err(1, "failed to reserve iova");
 	}
 
 	if (op_write) {
 		fprintf(stderr, "reading payload\n");
 
-		ret = readmaxfd(fd, vaddr, 0x1000);
+		ret = readmaxfd(fd, vaddr, io_sz);
 		if (ret < 0)
 			err(1, "could not read fd");
 
@@ -110,7 +111,7 @@ int main(int argc, char **argv)
 		.nsid = cpu_to_le32(nsid),
 	};
 
-	ret = nvme_rq_map_prp(&ctrl, rq, &cmd, iova, 0x1000);
+	ret = nvme_rq_map_prp(&ctrl, rq, &cmd, iova, io_sz);
 	if (ret)
 		err(1, "could not map prps");
 
@@ -122,7 +123,7 @@ int main(int argc, char **argv)
 	if (op_read) {
 		fprintf(stderr, "writing payload\n");
 
-		ret = writeallfd(fd, vaddr, 0x1000);
+		ret = writeallfd(fd, vaddr, io_sz);
 		if (ret < 0)
 			err(1, "could not write fd");
 

--- a/examples/io.c
+++ b/examples/io.c
@@ -48,7 +48,7 @@ static struct opt_table opts[] = {
 int main(int argc, char **argv)
 {
 	void *vaddr;
-	uint64_t iova;
+	iova_t iova;
 	int ret;
 
 	struct nvme_ctrl ctrl = {};

--- a/examples/io.c
+++ b/examples/io.c
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-static bool op_write, op_read, op_same_iova, op_sgl, op_vector;
+static bool op_write, op_read, op_same_iova, op_sgl, op_vector, op_iova;
 static unsigned int op_len;
 static unsigned long nsid;
 static int fd;
@@ -38,6 +38,7 @@ static const struct nvme_ctrl_opts ctrl_opts = {
 
 static struct opt_table opts[] = {
 	OPT_SUBTABLE(opts_base, NULL),
+	OPT_WITHOUT_ARG("-i|--iova", opt_set_bool, &op_iova, "use iova based vector operation"),
 	OPT_WITH_ARG("-N|--nsid", opt_set_ulongval, opt_show_ulongval, &nsid, "namespace identifier"),
 	OPT_WITHOUT_ARG("-w|--write", opt_set_bool, &op_write, "perform a write"),
 	OPT_WITHOUT_ARG("-r|--read", opt_set_bool, &op_read, "perform a read"),
@@ -52,6 +53,7 @@ static struct opt_table opts[] = {
 
 int main(int argc, char **argv)
 {
+	struct iova_vec iovav[2];
 	size_t io_sz = 0x1000;
 	struct iovec iov[2];
 	void *vaddr;
@@ -120,10 +122,17 @@ int main(int argc, char **argv)
 	};
 
 	if (op_vector) {
-		iov[0].iov_base = vaddr + (io_sz / 2);
-		iov[0].iov_len = io_sz / 2;
-		iov[1].iov_base = vaddr;
-		iov[1].iov_len = io_sz / 2;
+		if (op_iova) {
+			iovav[0].iova = iova + (io_sz / 2);
+			iovav[0].len = io_sz / 2;
+			iovav[1].iova = iova;
+			iovav[1].len = io_sz / 2;
+		} else {
+			iov[0].iov_base = vaddr + (io_sz / 2);
+			iov[0].iov_len = io_sz / 2;
+			iov[1].iov_base = vaddr;
+			iov[1].iov_len = io_sz / 2;
+		}
 		/*
 		 * note: this assumes the device has an lba size of 512B.
 		 * A 0xf (Data SGL Length Invalid) status code will be
@@ -132,17 +141,28 @@ int main(int argc, char **argv)
 		cmd.rw.nlb = cpu_to_le16(15);
 		niov = 2;
 	} else {
-		iov[0].iov_base = vaddr;
-		iov[0].iov_len = io_sz;
+		if (op_iova) {
+			iovav[0].iova = iova;
+			iovav[0].len = io_sz;
+		} else {
+			iov[0].iov_base = vaddr;
+			iov[0].iov_len = io_sz;
+		}
 		niov = 1;
 	}
 
 	if (op_sgl) {
-		ret = nvme_rq_mapv_sgl(&ctrl, rq, &cmd, iov, niov);
+		if (op_iova)
+			ret = nvme_rq_mapv_iova_sgl(&ctrl, rq, &cmd, iovav, niov);
+		else
+			ret = nvme_rq_mapv_sgl(&ctrl, rq, &cmd, iov, niov);
 		if (ret)
 			err(1, "could not map sgls");
 	} else if (op_vector) {
-		ret = nvme_rq_mapv_prp(&ctrl, rq, &cmd, iov, niov);
+		if (op_iova)
+			ret = nvme_rq_mapv_iova_prp(&ctrl, rq, &cmd, iovav, niov);
+		else
+			ret = nvme_rq_mapv_prp(&ctrl, rq, &cmd, iov, niov);
 		if (ret)
 			err(1, "could not map vectored prps");
 	} else {

--- a/examples/io.c
+++ b/examples/io.c
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-static bool op_write, op_read;
+static bool op_write, op_read, op_same_iova;
 static unsigned int op_len;
 static unsigned long nsid;
 static int fd;
@@ -41,6 +41,8 @@ static struct opt_table opts[] = {
 	OPT_WITH_ARG("-N|--nsid", opt_set_ulongval, opt_show_ulongval, &nsid, "namespace identifier"),
 	OPT_WITHOUT_ARG("-w|--write", opt_set_bool, &op_write, "perform a write"),
 	OPT_WITHOUT_ARG("-r|--read", opt_set_bool, &op_read, "perform a read"),
+	OPT_WITHOUT_ARG("-S|--same-iova", opt_set_bool, &op_same_iova,
+			"use memory with the same iova"),
 	OPT_WITH_ARG("-z|--size", opt_set_uintval_bi, opt_show_uintval_bi, &op_len, "size of operation"),
 	OPT_ENDTABLE,
 };
@@ -77,10 +79,19 @@ int main(int argc, char **argv)
 	if (nvme_create_ioqpair(&ctrl, 1, 64, -1, 0x0))
 		err(1, "could not create io queue pair");
 
-	vaddr = mmap(NULL, 0x1000, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+	if (op_same_iova) {
+		vaddr = iommu_alloc_same_iova(__iommu_ctx(&ctrl), 0x1000);
+		if (!vaddr)
+			err(1, "unable to allocate memory with same address as the iova");
 
-	if (iommu_map_vaddr(__iommu_ctx(&ctrl), vaddr, 0x1000, &iova, 0x0))
-		err(1, "failed to reserve iova");
+		iova = same_iova(vaddr);
+	} else {
+		vaddr = mmap(NULL, 0x1000, PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+
+		if (iommu_map_vaddr(__iommu_ctx(&ctrl), vaddr, 0x1000, &iova, 0x0))
+			err(1, "failed to reserve iova");
+	}
 
 	if (op_write) {
 		fprintf(stderr, "reading payload\n");

--- a/examples/iopf.c
+++ b/examples/iopf.c
@@ -36,7 +36,7 @@
 #define REG_ADDR 0x0
 #define REG_CMD  0x8
 
-#define IOVA_BASE 0xfef00000
+#define IOVA_BASE ((iova_t)0xfef00000)
 
 static struct opt_table opts[] = {
 	OPT_SUBTABLE(opts_base, NULL),

--- a/examples/iopf.c
+++ b/examples/iopf.c
@@ -48,7 +48,7 @@ struct vfio_pci_device pdev;
 int main(int argc, char **argv)
 {
 	void *bar0;
-	uint64_t iova = IOVA_BASE;
+	iova_t iova = IOVA_BASE;
 	ssize_t len;
 	void *vaddr;
 

--- a/examples/perf.c
+++ b/examples/perf.c
@@ -193,7 +193,7 @@ static void run(void)
 
 		nvme_rq_prep_cmd(rq, &iod->cmd);
 
-		iova += 0x1000;
+		iova += (iova_t)0x1000;
 
 		rq->opaque = iod;
 

--- a/examples/perf.c
+++ b/examples/perf.c
@@ -157,7 +157,7 @@ static void run(void)
 	uint64_t twarmup, trun, tupdate;
 	bool warmup = (warmup_in_seconds > 0);
 	float iops, mbps, lavg, lmin, lmax;
-	uint64_t iova;
+	iova_t iova;
 	void *mem;
 	unsigned int to_submit = io_depth;
 

--- a/include/vfn/iommu/dma.h
+++ b/include/vfn/iommu/dma.h
@@ -105,6 +105,31 @@ int iommu_unmap_vaddr(struct iommu_ctx *ctx, void *vaddr, size_t *len);
  */
 int iommu_unmap_all(struct iommu_ctx *ctx);
 
+/**
+ * iommu_alloc_same_iova - Allocate a buffer where the iova value is the same
+ *	as the virtual address
+ * @ctx: &struct iommu_ctx
+ * @len: number of bytes to map
+ *
+ * In order to avoid having to look up an iova from a virtual address or
+ * to pass around both a virtual address and iova, allocate memory that
+ * has the same virtual address as the iova.
+ *
+ * Return: pointer to allocated memory or ``NULL`` on failure.
+ */
+void *iommu_alloc_same_iova(struct iommu_ctx *ctx, size_t len);
+
+/**
+ * iommu_free_same_iova - Free memory allocated with iommu_alloc_same_iova()
+ * @ctx: &struct iommu_ctx
+ * @vaddr: virtual memory address to unmap
+ *
+ * Unmap memory allocated with iommu_alloc_same_iova().
+ *
+ * Return: ``0`` on success, ``-1`` on error and sets ``errno``.
+ */
+int iommu_free_same_iova(struct iommu_ctx *ctx, void *vaddr);
+
 #ifndef IOMMU_IOAS_IOVA_RANGES
 struct iommu_iova_range {
 	iova_t __attribute__((aligned(8))) start;

--- a/include/vfn/iommu/dma.h
+++ b/include/vfn/iommu/dma.h
@@ -19,6 +19,11 @@ typedef uint64_t __attribute__((nocast)) iova_t;
 typedef uint64_t iova_t;
 #endif
 
+struct iova_vec {
+	iova_t iova;
+	size_t len;
+};
+
 /**
  * enum iommu_map_flags - Flags for DMA mapping
  * @IOMMU_MAP_FIXED_IOVA: If cleared, an appropriate IOVA will be allocated

--- a/include/vfn/iommu/dma.h
+++ b/include/vfn/iommu/dma.h
@@ -25,6 +25,17 @@ struct iova_vec {
 };
 
 /**
+ * same_iova() - annotate casts where the iova is known to be
+ *               the same as the virtual address
+ * @ptr: pointer to memory created by iommu_alloc_same_iova()
+ *
+ * When iommu_alloc_same_iova() is used the virtual address and iova
+ * are the same. Use this macro to annotate conversions where this is
+ * known to be the case.
+ */
+#define same_iova(ptr) ((iova_t __force)ptr)
+
+/**
  * enum iommu_map_flags - Flags for DMA mapping
  * @IOMMU_MAP_FIXED_IOVA: If cleared, an appropriate IOVA will be allocated
  * @IOMMU_MAP_EPHEMERAL: If set, the mapping is considered temporary

--- a/include/vfn/iommu/dma.h
+++ b/include/vfn/iommu/dma.h
@@ -13,7 +13,11 @@
 #ifndef LIBVFN_IOMMU_DMA_H
 #define LIBVFN_IOMMU_DMA_H
 
+#ifdef __CHECKER__
+typedef uint64_t __attribute__((nocast)) iova_t;
+#else
 typedef uint64_t iova_t;
+#endif
 
 /**
  * enum iommu_map_flags - Flags for DMA mapping

--- a/include/vfn/iommu/dma.h
+++ b/include/vfn/iommu/dma.h
@@ -13,6 +13,8 @@
 #ifndef LIBVFN_IOMMU_DMA_H
 #define LIBVFN_IOMMU_DMA_H
 
+typedef uint64_t iova_t;
+
 /**
  * enum iommu_map_flags - Flags for DMA mapping
  * @IOMMU_MAP_FIXED_IOVA: If cleared, an appropriate IOVA will be allocated
@@ -51,7 +53,7 @@ enum iommu_map_flags {
  *
  * Return: ``0`` on success, ``-1`` on error and sets ``errno``.
  */
-int iommu_map_vaddr(struct iommu_ctx *ctx, void *vaddr, size_t len, uint64_t *iova,
+int iommu_map_vaddr(struct iommu_ctx *ctx, void *vaddr, size_t len, iova_t *iova,
 		    unsigned long flags);
 
 /**
@@ -73,7 +75,7 @@ int iommu_map_vaddr(struct iommu_ctx *ctx, void *vaddr, size_t len, uint64_t *io
  * Return: ``0`` on success, ``-1`` on error and sets ``errno``.
  */
 int iommu_map_vaddr_align(struct iommu_ctx *ctx, void *vaddr, size_t len,
-			  size_t align, uint64_t *iova, unsigned long flags);
+			  size_t align, iova_t *iova, unsigned long flags);
 
 /**
  * iommu_unmap_vaddr - Unmap a virtual memory address in the IOMMU
@@ -101,8 +103,8 @@ int iommu_unmap_all(struct iommu_ctx *ctx);
 
 #ifndef IOMMU_IOAS_IOVA_RANGES
 struct iommu_iova_range {
-	__aligned_u64 start;
-	__aligned_u64 last;
+	iova_t __attribute__((aligned(8))) start;
+	iova_t __attribute__((aligned(8))) last;
 };
 #endif
 
@@ -117,7 +119,7 @@ struct iommu_iova_range {
  *
  * Return: ``true`` on success, ``false`` if no mapping was found.
  */
-bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, uint64_t *iova);
+bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, iova_t *iova);
 
 /**
  * iommu_translate_iova - Translate a I/O virtual address into a virtual address
@@ -131,7 +133,7 @@ bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, uint64_t *iova);
  * Return: > 0 remain size of the map from @vaddr on success, ``-1`` on error
  * and sets ``errno``.
  */
-ssize_t iommu_translate_iova(struct iommu_ctx *ctx, uint64_t iova, void **vaddr);
+ssize_t iommu_translate_iova(struct iommu_ctx *ctx, iova_t iova, void **vaddr);
 
 /**
  * iommu_get_iova_ranges - Get iova ranges

--- a/include/vfn/iommu/dmabuf.h
+++ b/include/vfn/iommu/dmabuf.h
@@ -43,7 +43,7 @@ struct iommu_dmabuf {
 	struct iommu_ctx *ctx;
 
 	void *vaddr;
-	uint64_t iova;
+	iova_t iova;
 	ssize_t len;
 };
 

--- a/include/vfn/nvme/ctrl.h
+++ b/include/vfn/nvme/ctrl.h
@@ -113,7 +113,7 @@ struct nvme_ctrl {
 	struct {
 		int bar;
 		void *vaddr;
-		uint64_t iova;
+		iova_t iova;
 		size_t size;
 	} cmb;
 };

--- a/include/vfn/nvme/rq.h
+++ b/include/vfn/nvme/rq.h
@@ -234,7 +234,7 @@ int nvme_rq_map_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *
  * subsequent entries MUST be page aligned.
  *
  * This helper uses a pre-allocated PRP list page within @rq and same with
- * calling ``nvme_mapv_prp(ctrl, rq->page.vaddr, cmd, iova, niov)``;
+ * calling ``nvme_mapv_prp(ctrl, rq->page.vaddr, rq->page.iova, cmd, iova, niov)``;
  *
  * Return: ``0`` on success, ``-1`` on error and sets errno.
  */
@@ -253,7 +253,7 @@ int nvme_rq_mapv_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd 
  * Map the memory contained in @iov into the request SGL.
  *
  * This helper uses a pre-allocated SGL segment list page within @rq and same
- * with calling ``nvme_mapv_sgl(ctrl, rq->page.vaddr, cmd, iova, niov)``;
+ * with calling ``nvme_mapv_sgl(ctrl, rq->page.vaddr, rq->page.iova, cmd, iova, niov)``;
  *
  * Return: ``0`` on success, ``-1`` on error and sets errno.
  */

--- a/include/vfn/nvme/rq.h
+++ b/include/vfn/nvme/rq.h
@@ -27,7 +27,7 @@ struct nvme_rq {
 
 	struct {
 		void *vaddr;
-		uint64_t iova;
+		iova_t iova;
 	} page;
 
 	struct nvme_rq *rq_next;
@@ -217,7 +217,7 @@ static inline void nvme_rq_exec(struct nvme_rq *rq, union nvme_cmd *cmd)
  *
  * Return: ``0`` on success, ``-1`` on error and sets errno.
  */
-int nvme_rq_map_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd, uint64_t iova,
+int nvme_rq_map_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd, iova_t iova,
 		    size_t len);
 
 /**

--- a/include/vfn/nvme/rq.h
+++ b/include/vfn/nvme/rq.h
@@ -242,6 +242,27 @@ int nvme_rq_mapv_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd 
 		     struct iovec *iov, int niov);
 
 /**
+ * nvme_rq_mapv_iova_prp - Set up the Physical Region Pages in the data pointer of
+ *                         the command from an iova_vec.
+ * @ctrl: &struct nvme_ctrl
+ * @rq: Request tracker (&struct nvme_rq)
+ * @cmd: NVMe command prototype (&union nvme_cmd)
+ * @iov: array of iova_vecs
+ * @niov: number of iova_vec in @iov
+ *
+ * Map the memory contained in @iov into the request PRPs. The first entry is
+ * allowed to be unaligned, but the entry MUST end on a page boundary. All
+ * subsequent entries MUST be page aligned.
+ *
+ * This helper uses a pre-allocated PRP list page within @rq and same with
+ * calling ``nvme_mapv_iova_prp(ctrl, rq->page.vaddr, rq->page.iova, cmd, iova, niov)``;
+ *
+ * Return: ``0`` on success, ``-1`` on error and sets errno.
+ */
+int nvme_rq_mapv_iova_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
+			  struct iova_vec *iov, int niov);
+
+/**
  * nvme_rq_mapv_sgl - Set up a Scatter/Gather List in the data pointer of the
  *                    command from an iovec.
  * @ctrl: &struct nvme_ctrl
@@ -259,6 +280,25 @@ int nvme_rq_mapv_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd 
  */
 int nvme_rq_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
 		     struct iovec *iov, int niov);
+
+/**
+ * nvme_rq_mapv_iova_sgl - Set up a Scatter/Gather List in the data pointer of the
+ *                         command from an iova_vec.
+ * @ctrl: &struct nvme_ctrl
+ * @rq: Request tracker (&struct nvme_rq)
+ * @cmd: NVMe command prototype (&union nvme_cmd)
+ * @iov: array of iova_vecs
+ * @niov: number of iova_vec in @iovec
+ *
+ * Map the memory contained in @iov into the request SGL.
+ *
+ * This helper uses a pre-allocated SGL segment list page within @rq and same
+ * with calling ``nvme_mapv_iova_sgl(ctrl, rq->page.vaddr, rq->page.iova, cmd, iova, niov)``;
+ *
+ * Return: ``0`` on success, ``-1`` on error and sets errno.
+ */
+int nvme_rq_mapv_iova_sgl(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
+			  struct iova_vec *iov, int niov);
 
 /**
  * nvme_rq_mapv - Set up data pointer in the command from an iovec.

--- a/include/vfn/nvme/util.h
+++ b/include/vfn/nvme/util.h
@@ -132,6 +132,7 @@ int nvme_map_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, union nvme_cmd *cmd
  *                 the command from an iovec.
  * @ctrl: &struct nvme_ctrl
  * @prplist: The first PRP list page address
+ * @prplist_iova: The first PRP list iova address
  * @cmd: NVMe command prototype (&union nvme_cmd)
  * @iov: array of iovecs
  * @niov: number of iovec in @iovec
@@ -142,7 +143,7 @@ int nvme_map_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, union nvme_cmd *cmd
  *
  * Return: ``0`` on success, ``-1`` on error and sets errno.
  */
-int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist,
+int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, iova_t prplist_iova,
 		  union nvme_cmd *cmd, struct iovec *iov, int niov);
 
 /**
@@ -150,6 +151,7 @@ int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist,
  *                 command from an iovec.
  * @ctrl: &struct nvme_ctrl
  * @seglist: SGL segment list page address
+ * @seglist_iova: SGL segment list iova address
  * @cmd: NVMe command prototype (&union nvme_cmd)
  * @iov: array of iovecs
  * @niov: number of iovec in @iovec
@@ -158,8 +160,8 @@ int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist,
  *
  * Return: ``0`` on success, ``-1`` on error and sets errno.
  */
-int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seglist, union nvme_cmd *cmd,
-		  struct iovec *iov, int niov);
+int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seglist, iova_t seglist_iova,
+		  union nvme_cmd *cmd, struct iovec *iov, int niov);
 
 /**
  * nvme_vm_assign_max_flexible - Assign the maximum number of flexible resources

--- a/include/vfn/nvme/util.h
+++ b/include/vfn/nvme/util.h
@@ -147,6 +147,25 @@ int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, iova_t prplist_iov
 		  union nvme_cmd *cmd, struct iovec *iov, int niov);
 
 /**
+ * nvme_mapv_iova_prp - Set up the Physical Region Pages in the data pointer of
+ *                      the command from an iova_vec.
+ * @ctrl: &struct nvme_ctrl
+ * @prplist: The first PRP list page address
+ * @prplist_iova: The first PRP list iova address
+ * @cmd: NVMe command prototype (&union nvme_cmd)
+ * @iov: array of iova_vecs
+ * @niov: number of iova_vec in @iovec
+ *
+ * Map the memory contained in @iov into the request PRPs. The first entry is
+ * allowed to be unaligned, but the entry MUST end on a page boundary. All
+ * subsequent entries MUST be page aligned.
+ *
+ * Return: ``0`` on success, ``-1`` on error and sets errno.
+ */
+int nvme_mapv_iova_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, iova_t prplist_iova,
+		       union nvme_cmd *cmd, struct iova_vec *iov, int niov);
+
+/**
  * nvme_mapv_sgl - Set up a Scatter/Gather List in the data pointer of the
  *                 command from an iovec.
  * @ctrl: &struct nvme_ctrl
@@ -162,6 +181,23 @@ int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, iova_t prplist_iov
  */
 int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seglist, iova_t seglist_iova,
 		  union nvme_cmd *cmd, struct iovec *iov, int niov);
+
+/**
+ * nvme_mapv_iova_sgl - Set up a Scatter/Gather List in the data pointer of the
+ *                      command from an iova_vec.
+ * @ctrl: &struct nvme_ctrl
+ * @seglist: SGL segment list page address
+ * @seglist_iova: SGL segment list iova address
+ * @cmd: NVMe command prototype (&union nvme_cmd)
+ * @iov: array of iova_vecs
+ * @niov: number of iovec in @iovec
+ *
+ * Map the memory contained in @iov into the request SGL.
+ *
+ * Return: ``0`` on success, ``-1`` on error and sets errno.
+ */
+int nvme_mapv_iova_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seglist, iova_t seglist_iova,
+		       union nvme_cmd *cmd, struct iova_vec *iov, int niov);
 
 /**
  * nvme_vm_assign_max_flexible - Assign the maximum number of flexible resources

--- a/include/vfn/nvme/util.h
+++ b/include/vfn/nvme/util.h
@@ -125,7 +125,7 @@ int nvme_admin(struct nvme_ctrl *ctrl, union nvme_cmd *sqe, void *buf, size_t le
  * Return: ``0`` on success, ``-1`` on error and sets errno.
  */
 int nvme_map_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, union nvme_cmd *cmd,
-		 uint64_t iova, size_t len);
+		 iova_t iova, size_t len);
 
 /**
  * nvme_mapv_prp - Set up the Physical Region Pages in the data pointer of

--- a/src/iommu/context.c
+++ b/src/iommu/context.c
@@ -86,6 +86,7 @@ void iommu_ctx_init(struct iommu_ctx *ctx)
 	 */
 	ctx->iova_ranges[0].start = IOVA_MIN;
 	ctx->iova_ranges[0].last = IOVA_MAX_39BITS - 1;
+	ctx->iova_max = IOVA_MAX_39BITS - 1;
 
 	skiplist_init(&ctx->map.list);
 	pthread_rwlock_init(&ctx->map.lock, NULL);

--- a/src/iommu/context.c
+++ b/src/iommu/context.c
@@ -88,6 +88,8 @@ void iommu_ctx_init(struct iommu_ctx *ctx)
 	ctx->iova_ranges[0].last = IOVA_MAX_39BITS - 1;
 	ctx->iova_max = IOVA_MAX_39BITS - 1;
 
+	iommu_init_next_same(ctx);
+
 	skiplist_init(&ctx->map.list);
 	pthread_rwlock_init(&ctx->map.lock, NULL);
 }

--- a/src/iommu/context.c
+++ b/src/iommu/context.c
@@ -23,8 +23,8 @@
 
 #include "context.h"
 
-#define IOVA_MIN 0x10000
-#define IOVA_MAX_39BITS (1ULL << 39)
+#define IOVA_MIN	((iova_t)0x10000)
+#define IOVA_MAX_39BITS	((iova_t)(1ULL << 39))
 
 static inline bool __iommufd_is_available(void)
 {

--- a/src/iommu/context.h
+++ b/src/iommu/context.h
@@ -52,6 +52,7 @@ struct iommu_ctx {
 
 	int nranges;
 	struct iommu_iova_range *iova_ranges;
+	iova_t iova_max;
 
 	bool iommufd;
 };

--- a/src/iommu/context.h
+++ b/src/iommu/context.h
@@ -16,14 +16,14 @@ struct iommu_ctx;
 
 struct iommu_ctx_ops {
 	/* container/ioas ops */
-	int (*iova_reserve)(struct iommu_ctx *ctx, size_t len, uint64_t *iova,
+	int (*iova_reserve)(struct iommu_ctx *ctx, size_t len, iova_t *iova,
 			    unsigned long flags);
 	int (*iova_reserve_align)(struct iommu_ctx *ctx, size_t len, size_t align,
-				  uint64_t *iova, unsigned long flags);
+				  iova_t *iova, unsigned long flags);
 	void (*iova_put_ephemeral)(struct iommu_ctx *ctx);
-	int (*dma_map)(struct iommu_ctx *ctx, void *vaddr, size_t len, uint64_t *iova,
+	int (*dma_map)(struct iommu_ctx *ctx, void *vaddr, size_t len, iova_t *iova,
 		       unsigned long flags);
-	int (*dma_unmap)(struct iommu_ctx *ctx, uint64_t iova, size_t len);
+	int (*dma_unmap)(struct iommu_ctx *ctx, iova_t iova, size_t len);
 	int (*dma_unmap_all)(struct iommu_ctx *ctx);
 
 	/* device ops */
@@ -34,7 +34,7 @@ struct iommu_ctx_ops {
 struct iova_mapping {
 	void *vaddr;
 	size_t len;
-	uint64_t iova;
+	iova_t iova;
 
 	unsigned long flags;
 

--- a/src/iommu/context.h
+++ b/src/iommu/context.h
@@ -53,6 +53,7 @@ struct iommu_ctx {
 	int nranges;
 	struct iommu_iova_range *iova_ranges;
 	iova_t iova_max;
+	iova_t iova_next_same;
 
 	bool iommufd;
 };
@@ -67,3 +68,28 @@ struct iommu_ctx *iommufd_get_iommu_context(const char *name);
 
 void iommu_ctx_init(struct iommu_ctx *ctx);
 int iommu_iova_range_to_string(struct iommu_iova_range *range, char **str);
+
+/*
+ * iommu_alloc_same_iova() mmaps memory at an address equal to the iova, so
+ * the address returned by the same-iova allocator must fit within whatever
+ * virtual address space the kernel/architecture actually gives userspace,
+ * which can be much narrower than what the IOMMU reports as a valid iova
+ * (e.g. AMD-Vi's default page tables grow dynamically and report an aperture
+ * up to UINT64_MAX).
+ *
+ * 47 bits is the size of the default (4-level page table) address space on
+ * x86-64, and is also the default map window on 5-level systems until a
+ * process opts into the larger range, so it is a safe lower bound across
+ * kernel configurations.
+ */
+#define IOMMU_MAX_SAME_IOVA ((iova_t)((1ULL << 47) - 1))
+
+static inline void iommu_init_next_same(struct iommu_ctx *ctx)
+{
+	iova_t max = ctx->iova_max;
+
+	if (max > IOMMU_MAX_SAME_IOVA)
+		max = IOMMU_MAX_SAME_IOVA;
+
+	ctx->iova_next_same = (max / 4) + 1;
+}

--- a/src/iommu/dma.c
+++ b/src/iommu/dma.c
@@ -244,6 +244,57 @@ int iommu_unmap_all(struct iommu_ctx *ctx)
 	return 0;
 }
 
+void *iommu_alloc_same_iova(struct iommu_ctx *ctx, size_t len)
+{
+	iova_t iova;
+	void *vaddr;
+
+	len = ALIGN_UP(len, __VFN_PAGESIZE);
+
+retry:
+	if (ctx->iova_next_same + len >= ctx->iova_max ||
+	    ctx->iova_next_same + len >= IOMMU_MAX_SAME_IOVA) {
+		log_debug("same iova space is full\n");
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	vaddr = mmap((void *)ctx->iova_next_same, len, PROT_READ | PROT_WRITE,
+		     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, 0, 0);
+	if (vaddr == MAP_FAILED) {
+		if (errno == EEXIST) {
+			log_debug("unable to map memory at %08lx, retrying\n", ctx->iova_next_same);
+			ctx->iova_next_same += len;
+			goto retry;
+		}
+
+		log_debug("unable to map memory at %08lx: %m\n", ctx->iova_next_same);
+		return NULL;
+	}
+
+	iova = (iova_t)vaddr;
+
+	if (iommu_map_vaddr(ctx, vaddr, len, &iova, IOMMU_MAP_FIXED_IOVA)) {
+		log_debug("unable to map iova at %p\n", vaddr);
+		munmap(vaddr, len);
+		return NULL;
+	}
+
+	ctx->iova_next_same += len;
+
+	return vaddr;
+}
+
+int iommu_free_same_iova(struct iommu_ctx *ctx, void *vaddr)
+{
+	size_t len;
+
+	if (iommu_unmap_vaddr(ctx, vaddr, &len))
+		return -1;
+
+	return munmap(vaddr, len);
+}
+
 int iommu_get_iova_ranges(struct iommu_ctx *ctx, struct iommu_iova_range **ranges)
 {
 	*ranges = ctx->iova_ranges;

--- a/src/iommu/dma.c
+++ b/src/iommu/dma.c
@@ -220,7 +220,7 @@ static void __unmap_mapping(void *opaque, struct skiplist_node *n)
 	struct iommu_ctx *ctx = opaque;
 	struct iova_mapping *m = container_of_var(n, m, list);
 
-	log_fatal_if(ctx->ops.dma_unmap(ctx, m->len, m->iova),
+	log_fatal_if(ctx->ops.dma_unmap(ctx, m->iova, m->len),
 		     "failed to unmap dma (iova 0x%" PRIx64 " len %zu)\n", m->iova, m->len);
 
 	free(m);

--- a/src/iommu/dma.c
+++ b/src/iommu/dma.c
@@ -38,7 +38,7 @@ static int iova_cmp(const void *vaddr, const struct skiplist_node *n)
 	return 0;
 }
 
-static int iova_map_add(struct iova_map *map, void *vaddr, size_t len, uint64_t iova,
+static int iova_map_add(struct iova_map *map, void *vaddr, size_t len, iova_t iova,
 			unsigned long flags)
 {
 	__autowrlock(&map->lock);
@@ -101,7 +101,7 @@ static void UNUSED iova_map_clear(struct iova_map *map)
 	iova_map_clear_with(map, NULL, NULL);
 }
 
-bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, uint64_t *iova)
+bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, iova_t *iova)
 {
 	struct iova_mapping *m = iova_map_find(&ctx->map, vaddr);
 
@@ -113,10 +113,10 @@ bool iommu_translate_vaddr(struct iommu_ctx *ctx, void *vaddr, uint64_t *iova)
 	return false;
 }
 
-int iommu_map_vaddr(struct iommu_ctx *ctx, void *vaddr, size_t len, uint64_t *iova,
+int iommu_map_vaddr(struct iommu_ctx *ctx, void *vaddr, size_t len, iova_t *iova,
 		    unsigned long flags)
 {
-	uint64_t _iova;
+	iova_t _iova;
 
 	if (iommu_translate_vaddr(ctx, vaddr, &_iova))
 		goto out;
@@ -146,9 +146,9 @@ out:
 }
 
 int iommu_map_vaddr_align(struct iommu_ctx *ctx, void *vaddr, size_t len,
-			  size_t align, uint64_t *iova, unsigned long flags)
+			  size_t align, iova_t *iova, unsigned long flags)
 {
-	uint64_t _iova;
+	iova_t _iova;
 
 	if (flags & IOMMU_MAP_FIXED_IOVA) {
 		log_debug("IOMMU_MAP_FIXED_IOVA is not supported with alignment\n");
@@ -252,10 +252,10 @@ int iommu_get_iova_ranges(struct iommu_ctx *ctx, struct iommu_iova_range **range
 
 int iommu_iova_range_to_string(struct iommu_iova_range *r, char **str)
 {
-	return asprintf(str, "[0x%llx; 0x%llx]", r->start, r->last);
+	return asprintf(str, "[0x%" PRIx64 "; 0x%" PRIx64 "]", r->start, r->last);
 }
 
-ssize_t iommu_translate_iova(struct iommu_ctx *ctx, uint64_t iova, void **vaddr)
+ssize_t iommu_translate_iova(struct iommu_ctx *ctx, iova_t iova, void **vaddr)
 {
 	__autordlock(&ctx->map.lock);
 

--- a/src/iommu/iommufd.c
+++ b/src/iommu/iommufd.c
@@ -224,7 +224,7 @@ static int iommufd_put_device_fd(struct iommu_ctx *ctx UNUSED, const char *bdf)
 	return -1;
 }
 
-static int iommu_ioas_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_t len, uint64_t *iova,
+static int iommu_ioas_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_t len, iova_t *iova,
 				 unsigned long flags)
 {
 	struct iommu_ioas *ioas = container_of_var(ctx, ioas, ctx);
@@ -272,7 +272,7 @@ static int iommu_ioas_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_t len,
 	return 0;
 }
 
-static int iommu_ioas_do_dma_unmap(struct iommu_ctx *ctx, uint64_t iova, size_t len)
+static int iommu_ioas_do_dma_unmap(struct iommu_ctx *ctx, iova_t iova, size_t len)
 {
 	struct iommu_ioas *ioas = container_of_var(ctx, ioas, ctx);
 

--- a/src/iommu/iommufd.c
+++ b/src/iommu/iommufd.c
@@ -108,6 +108,8 @@ static int iommu_ioas_update_iova_ranges(struct iommu_ioas *ioas)
 			ioas->ctx.iova_max = (iova_t)ioas->ctx.iova_ranges[i].last;
 	}
 
+	iommu_init_next_same(&ioas->ctx);
+
 	if (logv(LOG_INFO)) {
 		for (int i = 0; i < ioas->ctx.nranges; i++) {
 			struct iommu_iova_range *r = &ioas->ctx.iova_ranges[i];

--- a/src/iommu/iommufd.c
+++ b/src/iommu/iommufd.c
@@ -239,7 +239,7 @@ static int iommu_ioas_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_t len,
 
 	if (flags & IOMMU_MAP_FIXED_IOVA) {
 		map.flags |= IOMMU_IOAS_MAP_FIXED_IOVA;
-		map.iova = *iova;
+		map.iova = (uint64_t)*iova;
 	}
 
 	if (flags & IOMMU_MAP_NOWRITE)
@@ -263,7 +263,7 @@ static int iommu_ioas_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_t len,
 	if (flags & IOMMU_MAP_FIXED_IOVA)
 		return 0;
 
-	*iova = map.iova;
+	*iova = (iova_t)map.iova;
 
 	trace_guard(IOMMUFD_IOAS_MAP_DMA) {
 		trace_emit("allocated iova 0x%" PRIx64 "\n", *iova);
@@ -279,7 +279,7 @@ static int iommu_ioas_do_dma_unmap(struct iommu_ctx *ctx, iova_t iova, size_t le
 	struct iommu_ioas_unmap unmap = {
 		.size = sizeof(unmap),
 		.ioas_id = ioas->id,
-		.iova = iova,
+		.iova = (uint64_t)iova,
 		.length = len
 	};
 
@@ -297,7 +297,7 @@ static int iommu_ioas_do_dma_unmap(struct iommu_ctx *ctx, iova_t iova, size_t le
 
 static int iommu_ioas_do_dma_unmap_all(struct iommu_ctx *ctx)
 {
-	return iommu_ioas_do_dma_unmap(ctx, 0, UINT64_MAX);
+	return iommu_ioas_do_dma_unmap(ctx, (iova_t)0, UINT64_MAX);
 }
 
 static const struct iommu_ctx_ops iommufd_ops = {

--- a/src/iommu/iommufd.c
+++ b/src/iommu/iommufd.c
@@ -102,6 +102,12 @@ static int iommu_ioas_update_iova_ranges(struct iommu_ioas *ioas)
 		}
 	}
 
+	ioas->ctx.iova_max = (iova_t)0;
+	for (int i = 0; i < ioas->ctx.nranges; i++) {
+		if ((iova_t)ioas->ctx.iova_ranges[i].last > ioas->ctx.iova_max)
+			ioas->ctx.iova_max = (iova_t)ioas->ctx.iova_ranges[i].last;
+	}
+
 	if (logv(LOG_INFO)) {
 		for (int i = 0; i < ioas->ctx.nranges; i++) {
 			struct iommu_iova_range *r = &ioas->ctx.iova_ranges[i];

--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -54,7 +54,7 @@ struct vfio_group {
 };
 
 struct vfio_iova_free_range {
-	uint64_t start;
+	iova_t start;
 	uint64_t len;
 	struct skiplist_node list;
 };
@@ -70,7 +70,8 @@ struct vfio_container {
 	int nr_groups;
 
 	pthread_mutex_t lock;
-	uint64_t next, next_ephemeral, nephemerals;
+	iova_t next, next_ephemeral;
+	uint64_t nephemerals;
 	struct iommu_iova_range ephemerals;
 	struct skiplist free_iovas;
 
@@ -199,10 +200,10 @@ static int vfio_iommu_type1_get_capabilities(struct vfio_container *vfio)
 }
 #endif /* VFIO_IOMMU_INFO_CAPS */
 
-static bool __iova_reserve(struct iommu_iova_range *ranges, int nranges, uint64_t *next,
-			   size_t len, uint64_t *iova)
+static bool __iova_reserve(struct iommu_iova_range *ranges, int nranges, iova_t *next,
+			   size_t len, iova_t *iova)
 {
-	uint64_t _next = *next;
+	iova_t _next = *next;
 
 	for (int i = 0; i < nranges; i++) {
 		struct iommu_iova_range *r = &ranges[i];
@@ -210,7 +211,7 @@ static bool __iova_reserve(struct iommu_iova_range *ranges, int nranges, uint64_
 		if (r->last < _next)
 			continue;
 
-		_next = max_t(uint64_t, _next, r->start);
+		_next = max_t(iova_t, _next, r->start);
 
 		if (_next > r->last || r->last - _next + 1 < len)
 			continue;
@@ -225,19 +226,19 @@ static bool __iova_reserve(struct iommu_iova_range *ranges, int nranges, uint64_
 }
 
 static bool __iova_reserve_align(struct iommu_iova_range *ranges, int nranges,
-				 uint64_t *next, size_t len, size_t align,
-				 uint64_t *iova)
+				 iova_t *next, size_t len, size_t align,
+				 iova_t *iova)
 {
-	uint64_t _next = *next;
+	iova_t _next = *next;
 
 	for (int i = 0; i < nranges; i++) {
 		struct iommu_iova_range *r = &ranges[i];
-		uint64_t aligned;
+		iova_t aligned;
 
 		if (r->last < _next)
 			continue;
 
-		_next = max_t(uint64_t, _next, r->start);
+		_next = max_t(iova_t, _next, r->start);
 		aligned = ALIGN_UP(_next, align);
 
 		/* overflow or out of range */
@@ -290,7 +291,7 @@ static struct vfio_iova_free_range *__iova_get_free_range(struct skiplist *free_
 }
 
 static bool __iova_get_free(struct skiplist *free_list, size_t len,
-			    uint64_t *iova)
+			    iova_t *iova)
 {
 	struct vfio_iova_free_range *range;
 
@@ -314,19 +315,19 @@ static bool __iova_get_free(struct skiplist *free_list, size_t len,
 	return true;
 }
 
-static void __iova_put_free(struct skiplist *free_list, uint64_t start, size_t len);
+static void __iova_put_free(struct skiplist *free_list, iova_t start, size_t len);
 
 static bool __iova_get_free_align(struct skiplist *free_list, size_t len,
-				  size_t align, uint64_t *iova)
+				  size_t align, iova_t *iova)
 {
 	struct vfio_iova_free_range *range, *best_fit = NULL;
 	struct skiplist_node *n, *next;
-	uint64_t best_aligned = 0;
+	iova_t best_aligned = 0;
 	size_t best_fit_avail = SIZE_MAX;
 
 	/* Find best-fit free range accounting for alignment padding */
 	skiplist_for_each_safe(free_list, n, next, 0) {
-		uint64_t aligned;
+		iova_t aligned;
 		size_t pad, avail;
 
 		if (n == NULL || n == &free_list->sentinel)
@@ -382,7 +383,7 @@ static bool __iova_get_free_align(struct skiplist *free_list, size_t len,
 	return true;
 }
 
-static void __iova_put_free(struct skiplist *free_list, uint64_t start, size_t len)
+static void __iova_put_free(struct skiplist *free_list, iova_t start, size_t len)
 {
 	struct skiplist_node *update[SKIPLIST_LEVELS] = {};
 	struct skiplist_node *prev_node, *next_node;
@@ -437,7 +438,7 @@ static void __iova_put_free(struct skiplist *free_list, uint64_t start, size_t l
 	skiplist_link(free_list, &new_range->list, update);
 }
 
-static int vfio_iommu_type1_iova_reserve(struct iommu_ctx *ctx, size_t len, uint64_t *iova,
+static int vfio_iommu_type1_iova_reserve(struct iommu_ctx *ctx, size_t len, iova_t *iova,
 					 unsigned long flags)
 {
 	struct vfio_container *vfio = container_of_var(ctx, vfio, ctx);
@@ -471,7 +472,7 @@ enomem:
 }
 
 static int vfio_iommu_type1_iova_reserve_align(struct iommu_ctx *ctx, size_t len,
-					       size_t align, uint64_t *iova,
+					       size_t align, iova_t *iova,
 					       unsigned long flags UNUSED)
 {
 	struct vfio_container *vfio = container_of_var(ctx, vfio, ctx);
@@ -503,7 +504,7 @@ static int vfio_iommu_type1_iova_reserve_align(struct iommu_ctx *ctx, size_t len
 
 static int vfio_iommu_type1_init(struct vfio_container *vfio)
 {
-	uint64_t iova;
+	iova_t iova;
 
 	if (vfio->iommu_set)
 		return 0;
@@ -759,7 +760,7 @@ static int vfio_put_device_fd(struct iommu_ctx *ctx, const char *bdf)
 }
 
 static int vfio_iommu_type1_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_t len,
-				       uint64_t *iova, unsigned long flags)
+				       iova_t *iova, unsigned long flags)
 {
 	struct vfio_container *vfio = container_of_var(ctx, vfio, ctx);
 
@@ -795,7 +796,7 @@ static int vfio_iommu_type1_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_
 	return 0;
 }
 
-static void vfio_iova_put(struct iommu_ctx *ctx, uint64_t iova, size_t len)
+static void vfio_iova_put(struct iommu_ctx *ctx, iova_t iova, size_t len)
 {
 	struct vfio_container *vfio = container_of_var(ctx, vfio, ctx);
 
@@ -807,7 +808,7 @@ static void vfio_iova_put(struct iommu_ctx *ctx, uint64_t iova, size_t len)
 	__iova_put_free(&vfio->free_iovas, iova, len);
 }
 
-static int vfio_iommu_type1_do_dma_unmap(struct iommu_ctx *ctx, uint64_t iova, size_t len)
+static int vfio_iommu_type1_do_dma_unmap(struct iommu_ctx *ctx, iova_t iova, size_t len)
 {
 	struct vfio_container *vfio = container_of_var(ctx, vfio, ctx);
 
@@ -835,7 +836,7 @@ static void vfio_iommu_type1_recycle_ephemeral_iovas(struct vfio_container *vfio
 	__autolock(&vfio->lock);
 
 	trace_guard(VFIO_IOMMU_TYPE1_RECYCLE_EPHEMERAL_IOVAS) {
-		trace_emit("recycling ephemeral range (0x%" PRIx64 " -> 0x%llx)\n",
+		trace_emit("recycling ephemeral range (0x%" PRIx64 " -> 0x%" PRIx64 ")\n",
 			   vfio->next_ephemeral, vfio->ephemerals.start);
 	}
 

--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -104,6 +104,12 @@ static void vfio_iommu_type1_get_cap_iova_ranges(struct iommu_ctx *ctx,
 
 	memcpy(ctx->iova_ranges, cap_iova_range->iova_ranges, len);
 
+	ctx->iova_max = (iova_t)0;
+	for (int i = 0; i < ctx->nranges; i++) {
+		if (ctx->iova_ranges[i].last > ctx->iova_max)
+			ctx->iova_max = ctx->iova_ranges[i].last;
+	}
+
 	if (logv(LOG_INFO)) {
 		for (int i = 0; i < ctx->nranges; i++) {
 			struct iommu_iova_range *r = &ctx->iova_ranges[i];

--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -304,7 +304,8 @@ static bool __iova_get_free(struct skiplist *free_list, size_t len,
 	if (range->len == len) {
 		struct skiplist_node *update[SKIPLIST_LEVELS] = {};
 
-		skiplist_find(free_list, &range->start, iova_free_range_cmp, update);
+		skiplist_find(free_list, (void *)&range->start,
+			      iova_free_range_cmp, update);
 		skiplist_erase(free_list, &range->list, update);
 		free(range);
 	} else {
@@ -322,7 +323,7 @@ static bool __iova_get_free_align(struct skiplist *free_list, size_t len,
 {
 	struct vfio_iova_free_range *range, *best_fit = NULL;
 	struct skiplist_node *n, *next;
-	iova_t best_aligned = 0;
+	iova_t best_aligned = (iova_t)0;
 	size_t best_fit_avail = SIZE_MAX;
 
 	/* Find best-fit free range accounting for alignment padding */
@@ -390,7 +391,8 @@ static void __iova_put_free(struct skiplist *free_list, iova_t start, size_t len
 	struct vfio_iova_free_range *new_range, *prev_range = NULL, *next_range = NULL;
 
 	/* Check if we can merge with adjacent ranges */
-	prev_node = skiplist_find_le(free_list, &start, iova_free_range_cmp, update);
+	prev_node = skiplist_find_le(free_list, (void *)&start,
+				     iova_free_range_cmp, update);
 	if (prev_node) {
 		prev_range = container_of_var(prev_node, prev_range, list);
 		/* Check if we can merge with previous range */
@@ -407,7 +409,7 @@ static void __iova_put_free(struct skiplist *free_list, iova_t start, size_t len
 					struct skiplist_node *del_update[SKIPLIST_LEVELS] = {};
 
 					prev_range->len += next_range->len;
-					skiplist_find(free_list, &next_range->start,
+					skiplist_find(free_list, (void *)&next_range->start,
 							iova_free_range_cmp, del_update);
 					skiplist_erase(free_list, next_node, del_update);
 					free(next_range);
@@ -418,7 +420,8 @@ static void __iova_put_free(struct skiplist *free_list, iova_t start, size_t len
 	}
 
 	/* Check if we can merge with next range */
-	next_node = skiplist_find_ge(free_list, &start, iova_free_range_cmp, update);
+	next_node = skiplist_find_ge(free_list, (void *)&start,
+				     iova_free_range_cmp, update);
 	if (next_node) {
 		next_range = container_of_var(next_node, next_range, list);
 		if (start + len == next_range->start) {
@@ -434,7 +437,7 @@ static void __iova_put_free(struct skiplist *free_list, iova_t start, size_t len
 	new_range->start = start;
 	new_range->len = len;
 
-	skiplist_find(free_list, &start, iova_free_range_cmp, update);
+	skiplist_find(free_list, (void *)&start, iova_free_range_cmp, update);
 	skiplist_link(free_list, &new_range->list, update);
 }
 
@@ -750,8 +753,8 @@ static int vfio_put_device_fd(struct iommu_ctx *ctx, const char *bdf)
 
 			vfio->fd = -1;
 			vfio->iommu_set = false;
-			vfio->next = 0;
-			vfio->next_ephemeral = 0;
+			vfio->next = (iova_t)0;
+			vfio->next_ephemeral = (iova_t)0;
 			vfio->nephemerals = 0;
 		}
 	}
@@ -768,7 +771,7 @@ static int vfio_iommu_type1_do_dma_map(struct iommu_ctx *ctx, void *vaddr, size_
 		.argsz = sizeof(dma_map),
 		.vaddr = (uintptr_t)vaddr,
 		.size  = len,
-		.iova  = *iova,
+		.iova  = (uint64_t)*iova,
 		.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
 	};
 
@@ -815,7 +818,7 @@ static int vfio_iommu_type1_do_dma_unmap(struct iommu_ctx *ctx, iova_t iova, siz
 	struct vfio_iommu_type1_dma_unmap dma_unmap = {
 		.argsz = sizeof(dma_unmap),
 		.size = len,
-		.iova = iova,
+		.iova = (uint64_t)iova,
 	};
 
 	trace_guard(VFIO_IOMMU_TYPE1_UNMAP_DMA) {

--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -110,6 +110,8 @@ static void vfio_iommu_type1_get_cap_iova_ranges(struct iommu_ctx *ctx,
 			ctx->iova_max = ctx->iova_ranges[i].last;
 	}
 
+	iommu_init_next_same(ctx);
+
 	if (logv(LOG_INFO)) {
 		for (int i = 0; i < ctx->nranges; i++) {
 			struct iommu_iova_range *r = &ctx->iova_ranges[i];

--- a/src/nvme/rq.c
+++ b/src/nvme/rq.c
@@ -39,7 +39,7 @@
 #include "types.h"
 
 int nvme_rq_map_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
-		    uint64_t iova, size_t len)
+		    iova_t iova, size_t len)
 {
 	return nvme_map_prp(ctrl, rq->page.vaddr, cmd, iova, len);
 }

--- a/src/nvme/rq.c
+++ b/src/nvme/rq.c
@@ -47,13 +47,13 @@ int nvme_rq_map_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *
 int nvme_rq_mapv_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
 		     struct iovec *iov, int niov)
 {
-	return nvme_mapv_prp(ctrl, rq->page.vaddr, cmd, iov, niov);
+	return nvme_mapv_prp(ctrl, rq->page.vaddr, rq->page.iova, cmd, iov, niov);
 }
 
 int nvme_rq_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
 		     struct iovec *iov, int niov)
 {
-	return nvme_mapv_sgl(ctrl, rq->page.vaddr, cmd, iov, niov);
+	return nvme_mapv_sgl(ctrl, rq->page.vaddr, rq->page.iova, cmd, iov, niov);
 }
 
 int nvme_rq_mapv(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,

--- a/src/nvme/rq.c
+++ b/src/nvme/rq.c
@@ -50,10 +50,22 @@ int nvme_rq_mapv_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd 
 	return nvme_mapv_prp(ctrl, rq->page.vaddr, rq->page.iova, cmd, iov, niov);
 }
 
+int nvme_rq_mapv_iova_prp(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
+			  struct iova_vec *iov, int niov)
+{
+	return nvme_mapv_iova_prp(ctrl, rq->page.vaddr, rq->page.iova, cmd, iov, niov);
+}
+
 int nvme_rq_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
 		     struct iovec *iov, int niov)
 {
 	return nvme_mapv_sgl(ctrl, rq->page.vaddr, rq->page.iova, cmd, iov, niov);
+}
+
+int nvme_rq_mapv_iova_sgl(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,
+			  struct iova_vec *iov, int niov)
+{
+	return nvme_mapv_iova_sgl(ctrl, rq->page.vaddr, rq->page.iova, cmd, iov, niov);
 }
 
 int nvme_rq_mapv(struct nvme_ctrl *ctrl, struct nvme_rq *rq, union nvme_cmd *cmd,

--- a/src/nvme/rq_test.c
+++ b/src/nvme/rq_test.c
@@ -22,7 +22,7 @@
 
 #define __max_prps 513
 
-bool iommu_translate_vaddr(struct iommu_ctx *ctx UNUSED, void *vaddr, uint64_t *iova)
+bool iommu_translate_vaddr(struct iommu_ctx *ctx UNUSED, void *vaddr, iova_t *iova)
 {
 	*iova = (uint64_t)vaddr;
 
@@ -30,7 +30,7 @@ bool iommu_translate_vaddr(struct iommu_ctx *ctx UNUSED, void *vaddr, uint64_t *
 }
 
 int iommu_map_vaddr(struct iommu_ctx *ctx UNUSED, void *vaddr UNUSED, size_t len UNUSED,
-		    uint64_t *iova UNUSED, unsigned long flags UNUSED)
+		    iova_t *iova UNUSED, unsigned long flags UNUSED)
 {
 	return 0;
 }

--- a/src/nvme/rq_test.c
+++ b/src/nvme/rq_test.c
@@ -73,35 +73,35 @@ int main(void)
 
 	/* test 512b aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x200) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x200) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
 
 	/* test 4k aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x1000) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x1000) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
 
 	/* test 4k + 8 aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x1008) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x1008) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
 
 	/* test 8k aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x2000) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x2000) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
 
 	/* test 8k + 16 aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x2010) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x2010) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -110,7 +110,7 @@ int main(void)
 
 	/* test 12k aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x3000) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x3000) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -119,7 +119,7 @@ int main(void)
 
 	/* test 12k + 24 aligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, 0x3018) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, 0x3018) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -128,35 +128,35 @@ int main(void)
 
 	/* test 512b unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x200) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x200) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
 
 	/* test 512 unaligned (nasty) */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1001000 - 4, 0x200) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1001000 - 4, 0x200) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1001000 - 4);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
 
 	/* test 4k unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x1000) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x1000) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
 
 	/* test 4k + 8 unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x1008) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x1008) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
 
 	/* test 4k + 8 unaligned (nasty) */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1001000 - 4, 0x1008) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1001000 - 4, 0x1008) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1001000 - 4);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -165,14 +165,14 @@ int main(void)
 
 	/* test 4k - 4 unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x1000 - 4) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x1000 - 4) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
 
 	/* test 8k unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x2000) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x2000) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -181,7 +181,7 @@ int main(void)
 
 	/* test 8k + 16 unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x2010) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x2010) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -190,14 +190,14 @@ int main(void)
 
 	/* test 8k - 4 unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x2000 - 4) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x2000 - 4) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
 
 	/* test 12k unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x3000) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x3000) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -207,7 +207,7 @@ int main(void)
 
 	/* test 12k + 24 unaligned */
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000004, 0x3018) == 0);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000004, 0x3018) == 0);
 
 	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
 	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
@@ -333,7 +333,7 @@ int main(void)
 	 */
 
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
-	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, 0x1000000, (__max_prps + 1) * 0x1000) == -1);
+	ok1(nvme_rq_map_prp(&ctrl, &rq, &cmd, (iova_t)0x1000000, (__max_prps + 1) * 0x1000) == -1);
 
 	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
 	iov[0] = (struct iovec) {.iov_base = (void *)0x1000004, .iov_len = 0x1000};

--- a/src/nvme/rq_test.c
+++ b/src/nvme/rq_test.c
@@ -62,8 +62,9 @@ int main(void)
 	leint64_t *prplist;
 	struct nvme_sgld *sglds;
 	struct iovec iov[8];
+	struct iova_vec iovav[8];
 
-	plan_tests(126);
+	plan_tests(179);
 
 	assert(pgmap((void **)&rq.page.vaddr, __VFN_PAGESIZE) > 0);
 
@@ -329,6 +330,123 @@ int main(void)
 
 
 	/*
+	 * PRPs with iova tests
+	 */
+
+	/* test 512b aligned 1-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x200};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 1) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
+
+	/* test 4k aligned 1-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 1) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
+
+	/* test 8k aligned 1-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x2000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 1) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
+
+	/* test 12k aligned 1-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x3000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 1) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
+	ok1(le64_to_cpu(prplist[0]) == 0x1001000);
+	ok1(le64_to_cpu(prplist[1]) == 0x1002000);
+
+	/* test 8k aligned 2-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 2) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
+
+	/* test 12k aligned 3-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = 0x1000};
+	iovav[2] = (struct iova_vec) {.iova = (iova_t)0x1002000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 3) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
+	ok1(le64_to_cpu(prplist[0]) == 0x1001000);
+	ok1(le64_to_cpu(prplist[1]) == 0x1002000);
+
+	/* test 12k aligned 2-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = 0x2000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 3) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
+	ok1(le64_to_cpu(prplist[0]) == 0x1001000);
+	ok1(le64_to_cpu(prplist[1]) == 0x1002000);
+
+	/* test 512b unaligned 1-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000004, .len = 0x200};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 1) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x0);
+
+	/* test 4k unaligned 1-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000004, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 1) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
+
+	/* test 8k unaligned 2-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000004, .len = 0x1000 - 4};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 2) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
+
+	/* test 12k unaligned 3-iovec */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000004, .len = 0x1000 - 4};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = 0x1000};
+	iovav[2] = (struct iova_vec) {.iova = (iova_t)0x1002000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 3) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000004);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == rq.page.iova);
+	ok1(le64_to_cpu(prplist[0]) == 0x1001000);
+	ok1(le64_to_cpu(prplist[1]) == 0x1002000);
+
+	/* test handling of unaligned length in last iovec entry */
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = 0x1000 - 4};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 2) == 0);
+
+	ok1(le64_to_cpu(cmd.dptr.prp1) == 0x1000000);
+	ok1(le64_to_cpu(cmd.dptr.prp2) == 0x1001000);
+
+
+	/*
 	 * Failure tests
 	 */
 
@@ -345,6 +463,17 @@ int main(void)
 	iov[1] = (struct iovec) {.iov_base = (void *)0x1001000, .iov_len = __max_prps * 0x1000};
 	ok1(nvme_rq_mapv_prp(&ctrl, &rq, &cmd, iov, 2) == -1);
 
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000004, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001004, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 2) == -1);
+
+	memset((void *)prplist, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1001000, .len = __max_prps * 0x1000};
+	ok1(nvme_rq_mapv_iova_prp(&ctrl, &rq, &cmd, iovav, 2) == -1);
+
+
 	/*
 	 * SGLs
 	 */
@@ -360,6 +489,25 @@ int main(void)
 	iov[0] = (struct iovec) {.iov_base = (void *)0x1000000, .iov_len = 0x1000};
 	iov[1] = (struct iovec) {.iov_base = (void *)0x1002000, .iov_len = 0x1000};
 	ok1(nvme_rq_mapv_sgl(&ctrl, &rq, &cmd, iov, 2) == 0);
+	ok1(le64_to_cpu(sglds[0].addr) == 0x1000000);
+	ok1(le64_to_cpu(sglds[1].addr) == 0x1002000);
+
+
+	/*
+	 * SGLs with iova tests
+	 */
+
+	memset((void *)sglds, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_sgl(&ctrl, &rq, &cmd, iovav, 1) == 0);
+	ok1(le64_to_cpu(cmd.dptr.sgl.addr) == 0x1000000);
+	ok1(le32_to_cpu(cmd.dptr.sgl.len) == 0x1000);
+	ok1(cmd.dptr.sgl.type == NVME_SGLD_TYPE_DATA_BLOCK);
+
+	memset((void *)sglds, 0x0, __VFN_PAGESIZE);
+	iovav[0] = (struct iova_vec) {.iova = (iova_t)0x1000000, .len = 0x1000};
+	iovav[1] = (struct iova_vec) {.iova = (iova_t)0x1002000, .len = 0x1000};
+	ok1(nvme_rq_mapv_iova_sgl(&ctrl, &rq, &cmd, iovav, 2) == 0);
 	ok1(le64_to_cpu(sglds[0].addr) == 0x1000000);
 	ok1(le64_to_cpu(sglds[1].addr) == 0x1002000);
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -80,7 +80,7 @@ int nvme_sync(struct nvme_ctrl *ctrl, struct nvme_sq *sq, union nvme_cmd *sqe, v
 {
 	struct nvme_cqe cqe;
 	struct nvme_rq *rq;
-	uint64_t iova;
+	iova_t iova;
 	bool do_unmap = false;
 	int ret = 0;
 
@@ -142,7 +142,7 @@ int nvme_admin(struct nvme_ctrl *ctrl, union nvme_cmd *sqe, void *buf, size_t le
 	return nvme_sync(ctrl, ctrl->adminq.sq, sqe, buf, len, cqe_copy);
 }
 
-static inline int __map_prp_first(leint64_t *prp1, leint64_t *prplist, uint64_t iova, size_t len,
+static inline int __map_prp_first(leint64_t *prp1, leint64_t *prplist, iova_t iova, size_t len,
 				  int pageshift)
 {
 	size_t pagesize = 1 << pageshift;
@@ -183,7 +183,7 @@ static inline int __map_prp_first(leint64_t *prp1, leint64_t *prplist, uint64_t 
 	return clamp_t(int, prpcount, 1, prpcount);
 }
 
-static inline int __map_prp_append(leint64_t *prplist, uint64_t iova, size_t len, int max_prps,
+static inline int __map_prp_append(leint64_t *prplist, iova_t iova, size_t len, int max_prps,
 				   int pageshift)
 {
 	int prpcount = max_t(int, 1, (int)len >> pageshift);
@@ -220,12 +220,12 @@ static inline void __set_prp2(leint64_t *prp2, leint64_t prplist, leint64_t prpl
 }
 
 int nvme_map_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, union nvme_cmd *cmd,
-		 uint64_t iova, size_t len)
+		 iova_t iova, size_t len)
 {
 	struct iommu_ctx *ctx = __iommu_ctx(ctrl);
 	int prpcount;
 	int pageshift = __mps_to_pageshift(ctrl->config.mps);
-	uint64_t prplist_iova;
+	iova_t prplist_iova;
 
 	if (!iommu_translate_vaddr(ctx, prplist, &prplist_iova)) {
 		errno = EFAULT;
@@ -301,7 +301,7 @@ int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist,
 	size_t pagesize = 1 << pageshift;
 	int max_prps = 1 << (pageshift - 3);
 	int ret, prpcount;
-	uint64_t iova, prplist_iova;
+	iova_t iova, prplist_iova;
 
 	if (!iommu_translate_vaddr(ctx, iov->iov_base, &iova)) {
 		errno = EFAULT;
@@ -367,7 +367,7 @@ invalid:
 	return -1;
 }
 
-static inline void __sgl_data(struct nvme_sgld *sgld, uint64_t iova, size_t len)
+static inline void __sgl_data(struct nvme_sgld *sgld, iova_t iova, size_t len)
 {
 	sgld->addr = cpu_to_le64(iova);
 	sgld->len = cpu_to_le32((uint32_t)len);
@@ -375,7 +375,7 @@ static inline void __sgl_data(struct nvme_sgld *sgld, uint64_t iova, size_t len)
 	sgld->type = NVME_SGLD_TYPE_DATA_BLOCK << 4;
 }
 
-static inline void __sgl_segment(struct nvme_sgld *sgld, uint64_t iova, int n)
+static inline void __sgl_segment(struct nvme_sgld *sgld, iova_t iova, int n)
 {
 	sgld->addr = cpu_to_le64(iova);
 	sgld->len = cpu_to_le32(n << 4);
@@ -392,8 +392,8 @@ int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, union nvme_cmd 
 	int max_sglds = 1 << (pageshift - 4);
 	int dword_align = ctrl->flags & NVME_CTRL_F_SGLS_DWORD_ALIGNMENT;
 
-	uint64_t iova;
-	uint64_t seg_iova;
+	iova_t iova;
+	iova_t seg_iova;
 
 	if (niov == 1) {
 		if (!iommu_translate_vaddr(ctx, iov->iov_base, &iova)) {

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -291,7 +291,7 @@ int nvme_vm_assign_max_flexible(struct nvme_ctrl *ctrl, uint16_t scid)
 	return 0;
 }
 
-int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist,
+int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, iova_t prplist_iova,
 		  union nvme_cmd *cmd, struct iovec *iov, int niov)
 {
 	struct iommu_ctx *ctx = __iommu_ctx(ctrl);
@@ -301,14 +301,9 @@ int nvme_mapv_prp(struct nvme_ctrl *ctrl, leint64_t *prplist,
 	size_t pagesize = 1 << pageshift;
 	int max_prps = 1 << (pageshift - 3);
 	int ret, prpcount;
-	iova_t iova, prplist_iova;
+	iova_t iova;
 
 	if (!iommu_translate_vaddr(ctx, iov->iov_base, &iova)) {
-		errno = EFAULT;
-		return -1;
-	}
-
-	if (!iommu_translate_vaddr(ctx, prplist, &prplist_iova)) {
 		errno = EFAULT;
 		return -1;
 	}
@@ -383,8 +378,8 @@ static inline void __sgl_segment(struct nvme_sgld *sgld, iova_t iova, int n)
 	sgld->type = NVME_SGLD_TYPE_LAST_SEGMENT << 4;
 }
 
-int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, union nvme_cmd *cmd,
-		  struct iovec *iov, int niov)
+int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, iova_t seg_iova,
+		  union nvme_cmd *cmd, struct iovec *iov, int niov)
 {
 	struct iommu_ctx *ctx = __iommu_ctx(ctrl);
 
@@ -393,7 +388,6 @@ int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, union nvme_cmd 
 	int dword_align = ctrl->flags & NVME_CTRL_F_SGLS_DWORD_ALIGNMENT;
 
 	iova_t iova;
-	iova_t seg_iova;
 
 	if (niov == 1) {
 		if (!iommu_translate_vaddr(ctx, iov->iov_base, &iova)) {
@@ -408,11 +402,6 @@ int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, union nvme_cmd 
 
 	if (niov > max_sglds) {
 		errno = EINVAL;
-		return -1;
-	}
-
-	if (!iommu_translate_vaddr(ctx, seg, &seg_iova)) {
-		errno = EFAULT;
 		return -1;
 	}
 

--- a/src/nvme/util.c
+++ b/src/nvme/util.c
@@ -362,6 +362,61 @@ invalid:
 	return -1;
 }
 
+int nvme_mapv_iova_prp(struct nvme_ctrl *ctrl, leint64_t *prplist, iova_t prplist_iova,
+		       union nvme_cmd *cmd, struct iova_vec *iov, int niov)
+{
+	int pageshift = __mps_to_pageshift(ctrl->config.mps);
+	size_t pagesize = 1 << pageshift;
+	int max_prps = 1 << (pageshift - 3);
+	int ret, prpcount;
+
+	/* map the first segment */
+	prpcount = __map_prp_first(&cmd->dptr.prp1, prplist, iov[0].iova, iov[0].len, pageshift);
+	if (prpcount < 0)
+		goto invalid;
+
+	/*
+	 * At this point, one of three conditions must hold:
+	 *
+	 *   a) a single prp entry was set up by __map_first, or
+	 *   b) the iovec only has a single entry, or
+	 *   c) the first buffer ends on a page size boundary
+	 *
+	 * If none holds, the buffer(s) within the iovec cannot be mapped given
+	 * the PRP alignment requirements.
+	 */
+	if (!(prpcount == 1 || niov == 1 || ALIGNED(iov[0].iova + iov[0].len, pagesize))) {
+		log_error("iov[0].iova/len invalid\n");
+
+		goto invalid;
+	}
+
+	/* map remaining iovec entries; these must be page size aligned */
+	for (int i = 1; i < niov; i++) {
+		/* all entries but the last must have a page size aligned len */
+		if (i < niov - 1 && !ALIGNED(iov[i].len, pagesize)) {
+			log_error("unaligned iov[%u].len (%zu)\n", i, iov[i].len);
+
+			goto invalid;
+		}
+
+		ret = __map_prp_append(&prplist[prpcount - 1], iov[i].iova, iov[i].len,
+				       max_prps - prpcount, pageshift);
+		if (ret < 0)
+			goto invalid;
+
+		prpcount += ret;
+	}
+
+	__set_prp2(&cmd->dptr.prp2, cpu_to_le64(prplist_iova), prplist[0], prpcount);
+
+	return 0;
+
+invalid:
+	errno = EINVAL;
+	return -1;
+}
+
 static inline void __sgl_data(struct nvme_sgld *sgld, iova_t iova, size_t len)
 {
 	sgld->addr = cpu_to_le64(iova);
@@ -419,6 +474,39 @@ int nvme_mapv_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, iova_t seg_iova
 		}
 
 		__sgl_data(&seg[i], iova, iov[i].iov_len);
+	}
+
+	cmd->flags |= NVME_FIELD_SET(NVME_CMD_FLAGS_PSDT_SGL_MPTR_CONTIG, CMD_FLAGS_PSDT);
+
+	return 0;
+}
+
+int nvme_mapv_iova_sgl(struct nvme_ctrl *ctrl, struct nvme_sgld *seg, iova_t seg_iova,
+		  union nvme_cmd *cmd, struct iova_vec *iov, int niov)
+{
+	int pageshift = __mps_to_pageshift(ctrl->config.mps);
+	int max_sglds = 1 << (pageshift - 4);
+	int dword_align = ctrl->flags & NVME_CTRL_F_SGLS_DWORD_ALIGNMENT;
+
+	if (niov == 1) {
+		__sgl_data(&cmd->dptr.sgl, iov->iova, iov->len);
+		return 0;
+	}
+
+	if (niov > max_sglds) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	__sgl_segment(&cmd->dptr.sgl, seg_iova, niov);
+
+	for (int i = 0; i < niov; i++) {
+		if (dword_align && (iov[i].iova & 0x3)) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		__sgl_data(&seg[i], iov[i].iova, iov[i].len);
 	}
 
 	cmd->flags |= NVME_FIELD_SET(NVME_CMD_FLAGS_PSDT_SGL_MPTR_CONTIG, CMD_FLAGS_PSDT);


### PR DESCRIPTION
In some situations it may not be practical to pass around an iova address along with its virtual address. To support these situations this PR aims to add a way to allocate memory where the iova is the same as the virtual address. It does this by dedicating a region in the iova address space well above the addresses that would be used by existing code and using the MAP_FIXED_NOREPLACE flag with mmap() to attempt to allocate memory with an address in this region. 

In addition to the core feature, this PR also adds type definitions and checking with sparse around iova addresses, fixes a parameter swap bug that was caught by the extra type checking, and adds some improvements to the examples to help demonstrate and test the feature.