### PR TITLE
iommu: vfio: pass vf_token only when SR-IOV is involved

### DIFF
--- a/include/vfn/pci/util.h
+++ b/include/vfn/pci/util.h
@@ -132,6 +132,29 @@ char *pci_get_vf_bdf(const char *pf_bdf, int vfnum);
 bool pci_is_vf(const char *bdf);
 
 /**
+ * pci_is_pf - Determine if a device is a physical function which support sriov.
+ * @bdf: device address
+ *
+ * Determine if the given device is a physical function which supports sriov.
+ *
+ * Return: ``true`` if the device is a physical function which supports sriov;
+ * ``false`` otherwise.
+ */
+bool pci_is_pf(const char *bdf);
+
+/**
+ * pci_is_sriov_supported - Determine if a device is involved in SR-IOV
+ * @bdf: device address
+ *
+ * Determine if the given device is either an SR-IOV capable physical function
+ * or a virtual function.
+ *
+ * Return: ``true`` if the device supports SR-IOV or is a virtual function;
+ * ``false`` otherwise.
+ */
+bool pci_is_sriov_supported(const char *bdf);
+
+/**
  * pci_vf_get_pf_bdf - Determine the physical function bdf given the bdf of a
  *                     virtual function
  * @bdf: virtual function device address

--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -700,12 +700,15 @@ static int vfio_get_device_fd(struct iommu_ctx *ctx, const char *bdf)
 
 	vf_token = getenv("VFTOKEN");
 	if (vf_token) {
-		log_info("using vf_token\n");
+		if (pci_is_sriov_supported(bdf)) {
+			log_info("using vf_token\n");
 
-		if (asprintf(&buf, "%s vf_token=%s", bdf, vf_token) < 0)
-			return -1;
+			if (asprintf(&buf, "%s vf_token=%s", bdf, vf_token) < 0)
+				return -1;
 
-		bdf = buf;
+			bdf = buf;
+		} else
+			log_info("VFTOKEN is set but ignored (device is not SR-IOV capable)\n");
 	}
 
 	ret_fd = ioctl(gfd, VFIO_GROUP_GET_DEVICE_FD, bdf);

--- a/src/pci/util.c
+++ b/src/pci/util.c
@@ -293,6 +293,23 @@ bool pci_is_vf(const char *bdf)
 	return access(path, F_OK) == 0;
 }
 
+bool pci_is_pf(const char *bdf)
+{
+	__autofree char *path = NULL;
+
+	if (asprintf(&path, "/sys/bus/pci/devices/%s/sriov_numvfs", bdf) < 0) {
+		log_debug("asprintf failed\n");
+		return false;
+	}
+
+	return access(path, F_OK) == 0;
+}
+
+bool pci_is_sriov_supported(const char *bdf)
+{
+	return pci_is_pf(bdf) || pci_is_vf(bdf);
+}
+
 int pci_vf_get_vfnum(const char *bdf)
 {
 	__autofree char *path = NULL;


### PR DESCRIPTION
The VF token mechanism is only relevant when SR-IOV is in use: either the device being opened is a VF, or it is a PF that supports SR-IOV. Passing a vf_token to VFIO_GROUP_GET_DEVICE_FD for a device that has nothing to do with SR-IOV causes the ioctl to fail.

Guard the vf_token handling with a new helper pci_is_sriov_supported, which returns true if the device is an SR-IOV capable PF (pci_is_pf) or a VF (pci_is_vf). pci_is_pf checks for the presence of sriov_numvfs in sysfs; devices that do not support SR-IOV simply lack that file.

Link: https://lore.kernel.org/all/20200319182730.16f4c476.cohuck@redhat.com