### PR TITLE
Fix crash when reopenning a device that previously failed to open

### DIFF
--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -617,6 +617,8 @@ static int vfio_get_group_fd(struct vfio_container *vfio,
 
 free_group_path:
 	free(group->path);
+	group->path = NULL;
+	group->fd = -1;
 
 	return -1;
 }


### PR DESCRIPTION
This patch fixes a leak if vfio_get_group_fd() that causes a crash if the calling code then goes on to try and open a different device.

The fix is simply to clear path and fd on the error path.