### PR TITLE
nvme/core: bail out if CAP reads back all-1s in queue configuration

### DIFF
--- a/src/nvme/core.c
+++ b/src/nvme/core.c
@@ -116,6 +116,13 @@ static int __nvme_configure_cq(struct nvme_ctrl *ctrl, int qid, int qsize,
 	uint8_t dstrd;
 
 	cap = le64_to_cpu(mmio_read64(ctrl->regs + NVME_REG_CAP));
+	if (cap == UINT64_MAX) {
+		log_error("failed to read cap; controller not accessible\n");
+
+		errno = ENODEV;
+		return -1;
+	}
+
 	dstrd = NVME_FIELD_GET(cap, CAP_DSTRD);
 
 	if (qid && qid > ctrl->config.ncqa + 1) {
@@ -209,6 +216,13 @@ static int __nvme_configure_sq(struct nvme_ctrl *ctrl, int qid, int qsize,
 	pagesize = __mps_to_pagesize(ctrl->config.mps);
 
 	cap = le64_to_cpu(mmio_read64(ctrl->regs + NVME_REG_CAP));
+	if (cap == UINT64_MAX) {
+		log_error("failed to read cap; controller not accessible\n");
+
+		errno = ENODEV;
+		return -1;
+	}
+
 	dstrd = NVME_FIELD_GET(cap, CAP_DSTRD);
 
 	if (qid && qid > ctrl->config.nsqa + 1) {


### PR DESCRIPTION
__nvme_configure_cq() and __nvme_configure_sq() read NVME_REG_CAP to derive the doorbell stride (and thus the doorbell addresses) used to initialize the host-side queue context. If the device becomes inaccessible (e.g. surprise removal), MMIO reads return all-1s. Using that value would compute bogus doorbell pointers and later dereference them, leading to a segfault.

Detect the all-1s (UINT64_MAX) CAP value and fail early with an error log and ENODEV instead of populating the queue with garbage.

These two functions only initialize the host-side queue context, so a device that becomes broken *after* a valid CAP has been read is fine; the concern is strictly a stale/invalid CAP observed at read time being propagated into the host context.