### PR TITLE
iommu/vfio: fix sparse warnings in container lock and file trailing newline

### DIFF
--- a/src/iommu/vfio.c
+++ b/src/iommu/vfio.c
@@ -101,7 +101,12 @@ struct vfio_container {
  * Devices in the same group share the same container (and thus same IOVA space).
  */
 static LIST_HEAD(active_containers);
-static pthread_mutex_t active_containers_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t active_containers_lock;
+
+static void __attribute__((constructor)) init_active_containers_lock(void)
+{
+	pthread_mutex_init(&active_containers_lock, NULL);
+}
 
 #ifdef VFIO_IOMMU_INFO_CAPS
 # ifdef VFIO_IOMMU_TYPE1_INFO_CAP_IOVA_RANGE


### PR DESCRIPTION
Initialize active_containers_lock with pthread_mutex_init() in a constructor instead of PTHREAD_MUTEX_INITIALIZER, which sparse flags as an implicit "plain integer as NULL pointer" cast through glibc's mutex initializer macro. Also add the missing trailing newline, which sparse warns about separately. Both currently fail the sparse CI job.

This fixes the following warnings:

../src/iommu/vfio.c:1079:1: warning: no newline at end of file
../src/iommu/vfio.c:104:49: warning: Using plain integer as NULL pointer
../src/iommu/vfio.c:104:49: warning: Using plain integer as NULL pointer

Fixes: ec0580d ("iommu: fix per-device context lifecycle and group sharing")