### PR TITLE
Demote two always-on init log messages to debug

### DIFF
--- a/src/iommu/iommufd.c
+++ b/src/iommu/iommufd.c
@@ -109,7 +109,7 @@ static int iommu_ioas_update_iova_ranges(struct iommu_ioas *ioas)
 
 	iommu_init_next_same(&ioas->ctx);
 
-	if (logv(LOG_INFO)) {
+	if (logv(LOG_DEBUG)) {
 		for (int i = 0; i < ioas->ctx.nranges; i++) {
 			struct iommu_iova_range *r = &ioas->ctx.iova_ranges[i];
 			__autofree char *str = NULL;
@@ -117,7 +117,7 @@ static int iommu_ioas_update_iova_ranges(struct iommu_ioas *ioas)
 			log_fatal_if(iommu_iova_range_to_string(r, &str) < 0,
 				     "iommu_iova_range_to_string\n");
 
-			log_info("iova range %d is %s\n", i, str);
+			log_debug("iova range %d is %s\n", i, str);
 		}
 	}
 

--- a/src/vfio/pci.c
+++ b/src/vfio/pci.c
@@ -104,7 +104,7 @@ static int vfio_pci_init_irq(struct vfio_pci_device *pci)
 		}
 	} while (!pci->dev.irq_info.count);
 
-	log_info("irq_info.count %d\n", pci->dev.irq_info.count);
+	log_debug("irq_info.count %d\n", pci->dev.irq_info.count);
 
 	return 0;
 }


### PR DESCRIPTION
Two messages are printed on every initialization at info level: the VFIO IRQ count, and one line per IOVA range from the iommufd backend. For example on my system that's four lines:

```
I iommu_ioas_update_iova_ranges (src/iommu/iommufd.c:120): iommu/iommufd: iova range 0 is [0x0; 0xfedfffff]
I iommu_ioas_update_iova_ranges (src/iommu/iommufd.c:120): iommu/iommufd: iova range 1 is [0xfef00000; 0xfcffffffff]
I iommu_ioas_update_iova_ranges (src/iommu/iommufd.c:120): iommu/iommufd: iova range 2 is [0x10000000000; 0xffffffffffffffff]
I vfio_pci_init_irq (src/vfio/pci.c:107): vfio/pci: irq_info.count 256
```

Both are useful when debugging DMA mapping or interrupt setup, but they're internal details that a caller doesn't act on, so log_debug() seems like the better fit and keeps the default output quiet.